### PR TITLE
fix(k8s,deploy): Reduce RBAC permissions to readonly

### DIFF
--- a/deploy/k8s/base/rbac.yaml
+++ b/deploy/k8s/base/rbac.yaml
@@ -10,9 +10,9 @@ metadata:
 rules:
 - apiGroups: ["*"]
   resources: ["*"]
-  verbs: ["*"]
-  # "Extensive" permissions requested. 
-  # This provides full access to all resources in all API groups.
+  verbs: ["get", "list"]
+  # "Extensive" permissions requested.
+  # This provides full read access to all resources in all API groups.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
In order to get closer to the princible of least privilege, reduce the rbac permissions to readonly.